### PR TITLE
Fix f-string syntax error in scenario printing

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -183,8 +183,7 @@ def main(yaml_file):
         command = scenario["command"]
         times = scenario["times"]
 
-        print(f"Running scenario: {
-            scenario.get('name', 'unnamed')} [{scenario_type}]")
+        print(f"Running scenario: {scenario.get('name', 'unnamed')} [{scenario_type}]")
 
         if scenario_type == "no_delay":
             run_no_delay_scenario(command, times)


### PR DESCRIPTION
Issue [#1](https://github.com/vtripolitakis/task_executor/issues/1#issue-2730063841)

### Description
This PR fixes a syntax error in `simulate.py` where an f-string was incorrectly split across multiple lines. The error was preventing the script from executing successfully.

### Changes Made
- Consolidated the multi-line f-string into a single line in the main scenario execution loop
- Maintained the same output format and functionality

### Before
```python
print(f"Running scenario: {
    scenario.get('name', 'unnamed')} [{scenario_type}]")
```

### After
```python
print(f"Running scenario: {scenario.get('name', 'unnamed')} [{scenario_type}]")
```

